### PR TITLE
deploy fix

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -1,10 +1,5 @@
 @servers(['web' => 'studycloud'])
 
 @task('deploy', ['on' => 'web', 'confirm' => true])
-	cd ~/beta
-	php artisan down
-	git pull origin production
-	composer install --no-dev --prefer-dist
-	php artisan migrate
-	php artisan up
+	deploy
 @endtask


### PR DESCRIPTION
we wanted the deploy command to be defined on the server, not in our Envoy script
this way, people can run the command without being able to run the Envoy script