### PR TITLE
fix deploy script (again - take 2)

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -1,5 +1,5 @@
 @servers(['web' => 'studycloud'])
 
 @task('deploy', ['on' => 'web', 'confirm' => true])
-	deploy
+	~/deploy
 @endtask


### PR DESCRIPTION
make envoy run a deployment script on the remote server instead of trying to use an aliased deploy function