### PR TITLE
basic CRUD for Topics

### DIFF
--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -30,7 +30,7 @@ class GetTopicTree extends Controller
 	 */
 	public function __invoke(Request $request)
 	{
-		$topic_id = $request->input('topic');
+		$topic_id = $request->input('id');
 		if ($topic_id == "")
 		{
 			$topic_id = null;

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -4,9 +4,16 @@ namespace App\Http\Controllers;
 
 use App\Topic;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class TopicController extends Controller
 {
+	function __construct()
+	{
+		// verify that the user is signed in for all methods except index, show, and json
+		$this->middleware('auth', ['except' => ['index', 'show']]);
+	}
+
 	/**
 	 * Display a listing of the topic.
 	 *
@@ -79,9 +86,15 @@ class TopicController extends Controller
 	 */
 	public function update(Request $request, Topic $topic)
 	{
-		$topic->name = $request->name;
-		$topic->author_id = Auth::id();
+		// first, validate the request
+		// note that we make the 'name' attribute required because there aren't any other attributes to validate
+		$validated = $request->validate([
+			'name' => 'string|required|max:255'
+		]);
 
+		// create a new Topic using mass assignment to add the 'name' attribute
+		$topic = $topic->fill($validated);
+		$topic->author_id = Auth::id();
 		$topic->save();
 	}
 

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -8,27 +8,27 @@ use Illuminate\Http\Request;
 class TopicController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of the topic.
      *
      * @return \Illuminate\Http\Response
      */
     public function index()
     {
-        //
+        return view('topics');
     }
 
     /**
-     * Show the form for creating a new resource.
+     * Show the form for creating a new topic.
      *
      * @return \Illuminate\Http\Response
      */
     public function create()
     {
-        //
+        // return a view for creating a new topic
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Store a newly created topic in storage.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
@@ -43,29 +43,31 @@ class TopicController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Display the specified topic.
      *
      * @param  \App\Topic  $topic
      * @return \Illuminate\Http\Response
      */
     public function show(Topic $topic)
     {
-        //
+        // let the js handle parsing the URL to determine which topic to retrieve
+        return view('topics');
     }
 
     /**
-     * Show the form for editing the specified resource.
+     * Show the form for editing the specified topic.
      *
      * @param  \App\Topic  $topic
      * @return \Illuminate\Http\Response
      */
     public function edit(Topic $topic)
     {
-        //
+        // return a view for editing a topic
+        // perhaps this functionality should be embedded in the topic tree, though?
     }
 
     /**
-     * Update the specified resource in storage.
+     * Update the specified topic in storage.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \App\Topic  $topic
@@ -80,7 +82,7 @@ class TopicController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Remove the specified topic from storage.
      *
      * @param  \App\Topic  $topic
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -7,89 +7,93 @@ use Illuminate\Http\Request;
 
 class TopicController extends Controller
 {
-    /**
-     * Display a listing of the topic.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        return view('topics');
-    }
+	/**
+	 * Display a listing of the topic.
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function index()
+	{
+		return view('topics');
+	}
 
-    /**
-     * Show the form for creating a new topic.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        // return a view for creating a new topic
-    }
+	/**
+	 * Show the form for creating a new topic.
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function create()
+	{
+		// return a view for creating a new topic
+	}
 
-    /**
-     * Store a newly created topic in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        $newTopic = new Topic;
-        $newTopic->name = $request->name;
-        $newTopic->author_id = Auth::id();
+	/**
+	 * Store a newly created topic in storage.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return \Illuminate\Http\Response
+	 */
+	public function store(Request $request)
+	{
+		// first, validate the request
+		$validated = $request->validate([
+			'name' => 'string|required|max:255'
+		]);
 
-        $newTopic->save();
-    }
+		// create a new Topic using mass assignment to add the 'name' attribute
+		$topic = (new Topic)->fill($validated);
+		$topic->author_id = Auth::id();
+		$topic->save();
+	}
 
-    /**
-     * Display the specified topic.
-     *
-     * @param  \App\Topic  $topic
-     * @return \Illuminate\Http\Response
-     */
-    public function show(Topic $topic)
-    {
-        // let the js handle parsing the URL to determine which topic to retrieve
-        return view('topics');
-    }
+	/**
+	 * Display the specified topic.
+	 *
+	 * @param  \App\Topic  $topic
+	 * @return \Illuminate\Http\Response
+	 */
+	public function show(Topic $topic)
+	{
+		// let the js handle parsing the URL to determine which topic to retrieve
+		return view('topics');
+	}
 
-    /**
-     * Show the form for editing the specified topic.
-     *
-     * @param  \App\Topic  $topic
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(Topic $topic)
-    {
-        // return a view for editing a topic
-        // perhaps this functionality should be embedded in the topic tree, though?
-    }
+	/**
+	 * Show the form for editing the specified topic.
+	 *
+	 * @param  \App\Topic  $topic
+	 * @return \Illuminate\Http\Response
+	 */
+	public function edit(Topic $topic)
+	{
+		// return a view for editing a topic
+		// perhaps this functionality should be embedded in the topic tree, though?
+	}
 
-    /**
-     * Update the specified topic in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Topic  $topic
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, Topic $topic)
-    {
-        $topic->name = $request->name;
-        $topic->author_id = Auth::id();
+	/**
+	 * Update the specified topic in storage.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \App\Topic  $topic
+	 * @return \Illuminate\Http\Response
+	 */
+	public function update(Request $request, Topic $topic)
+	{
+		$topic->name = $request->name;
+		$topic->author_id = Auth::id();
 
-        $topic->save();
-    }
+		$topic->save();
+	}
 
-    /**
-     * Remove the specified topic from storage.
-     *
-     * @param  \App\Topic  $topic
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(Topic $topic)
-    {
-        $topic->delete();
-    }
+	/**
+	 * Remove the specified topic from storage.
+	 *
+	 * @param  \App\Topic  $topic
+	 * @return \Illuminate\Http\Response
+	 */
+	public function destroy(Topic $topic)
+	{
+		$topic->delete();
+	}
 
 }

--- a/app/Http/Resources/TopicResource.php
+++ b/app/Http/Resources/TopicResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class TopicResource extends Resource
+{
+    /**
+     * Transform a Topic into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $date_format = 'M j, Y g:i A';
+        return [
+            'name' => $this->name,
+            'author_name' => $this->author->name(),
+            'created' => $this->created_at->format($date_format),
+            'updated' => $this->updated_at->format($date_format)
+        ];
+    }
+}

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -40,6 +40,15 @@ class Topic extends Model
 	}
 
 	/**
+	 * define the many-to-one relationship between topics and their author
+	 * @return User	the author of this topic
+	 */
+	public function author()
+	{
+		return $this->belongsTo(User::class);
+	}
+
+	/**
 	 * a wrapper function for attaching resources to prevent disallowedTopics from being added
 	 * @param  Illuminate\Database\Eloquent\Collection $new_resources the resources to be attached
 	 * @return void

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -11,7 +11,7 @@ class Topic extends Model
 	 *
 	 * @var array
 	 */
-	protected $fillable = ['name', 'author_id'];
+	protected $fillable = ['name'];
 
 	/**
 	 * returns all topics that have this topic as their parent

--- a/app/User.php
+++ b/app/User.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
@@ -26,6 +27,15 @@ class User extends Authenticatable
 	protected $hidden = [
 		'password', 'remember_token',
 	];
+
+	/**
+	 * return the full name of this user
+	 * @return string	the user's full name
+	 */
+	public function name()
+	{
+		return $this->fname . " " . $this->lname;
+	}
 
 	/**
 	 * returns the roles of this user. make sure to call get on the result!
@@ -112,5 +122,21 @@ class User extends Authenticatable
 			return $role;
 		}
 		throw new \InvalidArgumentException("this function only accepts either a string representing a role or an instance of Role");
+	}
+
+	/**
+	 * Retrieves the acceptable enum fields for a user type
+	 * @return array	the available resource types
+	 */
+	public static function getPossibleTypes() {
+		// Pulls column string from DB
+		// we use (new static) to get an instance of the current class
+		$enumStr = DB::select(DB::raw('SHOW COLUMNS FROM '.(new static)->getTable().' WHERE Field = "type"'))[0]->Type;
+		// Parse enum string
+		// should look something like:
+		// 		enum('text','link','file')
+		preg_match_all("/'([^']+)'/", $enumStr, $matches);
+		// Return matches
+		return isset($matches[1]) ? $matches[1] : [];
 	}
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\User;
+use App\Topic;
 use App\Resource;
 use Illuminate\Http\Request;
+use App\Http\Resources\TopicResource;
 use App\Http\Resources\ResourceResource;
 
 /*
@@ -37,12 +40,18 @@ Route::resource('resources', 'ResourceController', ['except' =>
 ]);
 
 Route::get('data/topic_tree', 'GetTopicTree');
+Route::get('data/topic',
+	function(Request $request)
+	{
+		return new TopicResource(Topic::find($request->query('id')));
+	}
+)->name('topics.json');
 Route::resource('topics', 'TopicController');
 
 Route::get('admins/{userid}',
 	function($user_id)
 	{
-		$user = App\User::find($user_id);
+		$user = User::find($user_id);
 		// return $user;
 		return view('admins', compact('user'));
 	}

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,13 +26,6 @@ Route::get('about',
 	}
 )->name('about');
 
-Route::get('topics',
-	function()
-	{
-		return view('topics');
-	}
-)->name('topics');
-
 Route::get('data/resource',
 	function(Request $request)
 	{
@@ -43,7 +36,8 @@ Route::resource('resources', 'ResourceController', ['except' =>
 	'index', 'edit'
 ]);
 
-Route::get('tree/data', 'TopicTreeController');
+Route::get('tree/data', 'GetTopicTree');
+Route::resource('topics', 'TopicController');
 
 Route::get('admins/{userid}',
 	function($user_id)

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Resource;
+use Illuminate\Http\Request;
+use App\Http\Resources\ResourceResource;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -15,27 +19,39 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::redirect('/', '/home', 301);
 
-Route::get('about', function(){
-	return view('about');
-})->name('about');
+Route::get('about',
+	function()
+	{
+		return view('about');
+	}
+)->name('about');
 
-// TEMPORARY FOR TESTING
-Route::get('resource', function(){
-	return view('resource');
-});
+Route::get('topics',
+	function()
+	{
+		return view('topics');
+	}
+)->name('topics');
 
-Route::get('topics', function(){
-	return view('topics');
-})->name('topics');
+Route::get('data/resource',
+	function(Request $request)
+	{
+		return new ResourceResource(Resource::find($request->query('id')));
+	}
+)->name('resources.json');
+Route::resource('resources', 'ResourceController', ['except' => 
+	'index', 'edit'
+]);
 
-Route::get('resource/{resource}', 'ResourceController@show');
+Route::get('tree/data', 'TopicTreeController');
 
-Route::get('tree/data', 'GetTopicTree');
-
-Route::get('admins/{userid}', function($user_id){
-	$user = App\User::find($user_id);
-	// return $user;
-	return view('admins', compact('user'));
-});
+Route::get('admins/{userid}',
+	function($user_id)
+	{
+		$user = App\User::find($user_id);
+		// return $user;
+		return view('admins', compact('user'));
+	}
+);
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,7 @@ Route::resource('resources', 'ResourceController', ['except' =>
 	'index', 'edit'
 ]);
 
-Route::get('tree/data', 'GetTopicTree');
+Route::get('data/topic_tree', 'GetTopicTree');
 Route::resource('topics', 'TopicController');
 
 Route::get('admins/{userid}',

--- a/tests/Feature/TopicsHttpTest.php
+++ b/tests/Feature/TopicsHttpTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Topic;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TopicsHttpTest extends TestCase
+{
+	/**
+	 * Test that CRUD routes for a Resource work correctly. Assumes you've already seeded the users table.
+	 *
+	 * @return void
+	 */
+	public function testAllRoutes()
+	{
+		// how many Topics do we have?
+		$topic_count = Topic::count();
+		// make a new topic but don't add it to database yet
+		$topic = factory(Topic::class)->make();
+		$user = User::find($topic->author_id);
+
+		// make a request to create a new topic
+		$response = $this->actingAs($user)->post('/topics/',
+			[
+				'name' => $topic->name
+			]
+		);
+		$new_topic = Topic::latest()->first();
+		// check: do we have a new Topic?
+		$response->assertSuccessful();
+		$this->assertEquals(Topic::count()-1, $topic_count);
+		// check: is the name what we expect?
+		$this->assertEquals($topic->name, $new_topic->name);
+
+		// edit the created topic
+		$new_name = "Test Topic";
+		$response = $this->actingAs($user)->patch('/topics/'.($new_topic->id),
+			[
+				'name' => $new_name
+			]
+		);
+		$new_topic = Topic::latest()->first();
+		// check: was the edit successful?
+		$response->assertSuccessful();
+		$this->assertEquals($new_name, $new_topic->name);
+
+		// delete the topic we created
+		$response = $this->actingAs($user)->delete('/topics/'.($new_topic->id));
+		// is the Topic gone?
+		$response->assertSuccessful();
+		$this->assertEquals(Topic::count(), $topic_count);
+	}
+}

--- a/tests/Feature/TopicsHttpTest.php
+++ b/tests/Feature/TopicsHttpTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\User;
 use App\Topic;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;


### PR DESCRIPTION
This pull request completes basic topic CRUD routes.
Unfortunately, `topics.destroy` is not complete (see issue #94) and is currently unsafe to use. There are also other unimplemented routes (mentioned in #94, as well). I hope to get to these later.

### Added Routes
HTTP Verb | URI | Action | Route Name | Accessed via JS
--- | --- | --- | --- | ---
GET | `/topics` | show the tree | topics.index | :x:
GET | `/topics/create` | show the topic creation page | topics.create | :x:
POST | `/topics` | create a new topic sent as JSON | topics.store | :heavy_check_mark:
GET | `/topics/{id}` | show this topic in the tree | topics.show | :x:
GET | `/data/topic?id={id}` | get the JSON representation of this topic | topics.json | :heavy_check_mark:
PATCH (or PUT) | `topics/{id}` | alter a current topic to match the attributes sent as JSON | topics.update | :heavy_check_mark:
DELETE | `/topics/{id}` | request that this topic be deleted | topics.destroy | :heavy_check_mark:

### Example JSON sent to `topics.store`
```
{
    "name":"Topic 1"
}
```

### Example JSON returned by `topics.json`
```
{
    "name": "Topic 1",
    "author_name": "Alden Cartwright",
    "created": "Aug 1, 2018 3:08 AM",
    "updated": "Aug 1, 2018 3:08 AM"
}
```

### Example JSON sent to `topics.update`
```
{
    "name":"New Topic 1"
}
```