### PR TITLE
add root to topic tree data

### DIFF
--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -64,8 +64,8 @@ class GetTopicTree extends Controller
 			$topic = Topic::find($topic_id);
 		}
 		// get the ancestors and descendants of this topic in a flat collection
-		$this->tree = (new TopicRepository)->ancestors($topic, $levels_up)->merge(
-			(new TopicRepository)->descendants($topic, $levels_down)
+		$this->tree = (new TopicRepository)->ancestors($topic, $levels_up, $root)->merge(
+			(new TopicRepository)->descendants($topic, $levels_down, $root)
 		);
 		// convert the data to the nodes/connections format
 		$this->tree = NodesAndConnections::convertTo($this->tree);

--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -57,7 +57,7 @@ class GetTopicTree extends Controller
 	 */
 	public function show($topic_id = 0, int $levels_up = null, int $levels_down = null)
 	{
-		$root = getRoot();
+		$root = Topic::getRoot();
 		$topic = null;
 		if ($topic_id != 0)
 		{

--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -57,6 +57,7 @@ class GetTopicTree extends Controller
 	 */
 	public function show($topic_id = 0, int $levels_up = null, int $levels_down = null)
 	{
+		$newRoot = collect(["parent" -> null, "topic" -> $topic_id]);
 		$topic = null;
 		if ($topic_id != 0)
 		{

--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -57,7 +57,7 @@ class GetTopicTree extends Controller
 	 */
 	public function show($topic_id = 0, int $levels_up = null, int $levels_down = null)
 	{
-		$newRoot = collect(["parent" -> null, "topic" -> $topic_id]);
+		$root = getRoot();
 		$topic = null;
 		if ($topic_id != 0)
 		{

--- a/app/Http/Controllers/GetTopicTree.php
+++ b/app/Http/Controllers/GetTopicTree.php
@@ -2,14 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\User;
 use App\Topic;
-use App\TopicParent;
 use App\Resource;
+use App\TopicParent;
+use Illuminate\Http\Request;
+use App\Helpers\NodesAndConnections;
 use App\Repositories\TopicRepository;
 use App\Repositories\ResourceRepository;
-use App\Helpers\NodesAndConnections;
-// use Barryvdh\Debugbar\Facade as Debugbar;
-use Illuminate\Http\Request;
 use Illuminate\Database\Eloquent\Collection;
 
 class GetTopicTree extends Controller
@@ -112,6 +112,10 @@ class GetTopicTree extends Controller
 	{
 		// add a 't' to the beginnning of the id
 		$node->put('id', 't'.$node['id']);
+		// add author name; it's more useful than the author id
+		// $node->put('author_name', User::find($node->get('author_id'))->name());
+		// send only the attributes that we need
+		$node = $node->only('id', 'name', 'author_id', 'created_at', 'updated_at');
 		return $node;
 	}
 
@@ -162,6 +166,10 @@ class GetTopicTree extends Controller
 	{
 		// add an 'r' to the beginnning of the id
 		$node->put('id', 'r'.$node['id']);
+		// add author name; it's more useful than the author id
+		// $node->put('author_name', User::find($node->get('author_id'))->name());
+		// send only the attributes that we need
+		$node = $node->only('id', 'name', 'author_id', 'created_at', 'updated_at');
 		return $node;
 	}
 

--- a/app/Repositories/TopicRepository.php
+++ b/app/Repositories/TopicRepository.php
@@ -40,7 +40,7 @@ class TopicRepository
 			$topLevelTopics = $topic.getTopLevelTopics(); //gets and stores top level topics
 			
 			foreach ($topLevelTopics as $topic) {  //iterates through each top level topic
-				$topic = collect(["parent" -> $root, "topic" -> $topic->id]); //adds pivot element to each topic
+				$topic->pivot = collect(["parent" => $root->id, "topic" => $topic->id]); //adds pivot element to each topic
 			}
 		} 
 		
@@ -87,8 +87,8 @@ class TopicRepository
 		$topicParents = $topic -> parents() -> get();
 		if ((is_empty($topicParents) == True) && (is_null($root) == False))
 		{
-			$root = collect(["parent" -> $root -> id, "topic" -> $topic]);
-			$tree.addResource($root);
+			$root->pivot = collect(["parent" => $root->id, "topic" => $topic->id]);
+			$tree->push($root);
 		}
 
 

--- a/app/Repositories/TopicRepository.php
+++ b/app/Repositories/TopicRepository.php
@@ -100,7 +100,7 @@ class TopicRepository
 				array_push($this->memoize, $topic->id);
 			}
 
-			if ($parents -> isEmpty() && is_null($root))
+			if ($parents->isEmpty() && !is_null($root))
 			{
 				$root->put("pivot", collect(["parent_id" => $root['id'], "topic_id" => $topic['id']]));
 				$tree->push($root);

--- a/app/Repositories/TopicRepository.php
+++ b/app/Repositories/TopicRepository.php
@@ -85,7 +85,7 @@ class TopicRepository
 		$tree = collect();
 
 		$topicParents = $topic -> parents() -> get();
-		if ((is_empty($topicParents) == True) && (is_null($root) == False))
+		if ((($topicParents -> isEmpty()) == True) && (is_null($root) == False))
 		{
 			$root->pivot = collect(["parent" => $root->id, "topic" => $topic->id]);
 			$tree->push($root);

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -65,4 +65,9 @@ class Topic extends Model
 	{
 		return $this->resources()->detachResources($old_resources);
 	}
+
+	/*public function setParentID($newID)
+	{
+		$this.parent = $newID
+	} */
 }

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
 
 class Topic extends Model
 {
@@ -66,8 +67,16 @@ class Topic extends Model
 		return $this->resources()->detachResources($old_resources);
 	}
 
-	/*public function setParentID($newID)
+	/* This function returns a collection that represents a root */
+	public static function getRoot()
 	{
-		$this.parent = $newID
-	} */
+		$root = collect([
+			"id"=>0, 
+			"name"=>"All Topics", 
+			"author_id"=>0, 
+			"created_at"=>Carbon::now(), 
+			"updated_at"=>Carbon::now()
+		]);
+		return $root;
+	} 
 }

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -74,8 +74,8 @@ class Topic extends Model
 			"id"=>0, 
 			"name"=>"All Topics", 
 			"author_id"=>0, 
-			"created_at"=>Carbon::now(), 
-			"updated_at"=>Carbon::now()
+			"created_at"=>Carbon::now()->toDateTimeString(), 
+			"updated_at"=>Carbon::now()->toDateTimeString()
 		]);
 		return $root;
 	} 


### PR DESCRIPTION
resolve #108 

The root topic is an imaginary node in the topic tree. This PR fabricates it in our code and incorporates it into the JSON returned by our tree. See #108 for why this was necessary.


#### How has the data changed?
1. If the user asks for all descendants of the root, we will now return connections from the root to the top level topics.
2. If the user asks for ancestors with the appropriate number of levels to include the root, we will include it as a node. We would also include connections between the root and the top level topics in this case.