### PR TITLE
attachable classes

### DIFF
--- a/app/Academic_Class.php
+++ b/app/Academic_Class.php
@@ -64,7 +64,7 @@ class Academic_Class extends Model
 			"author_id"=>0,
 			"created_at"=>Carbon::now()->toDateTimeString(),
 			"updated_at"=>Carbon::now()->toDateTimeString(),
-			"status"=>0
+			"status"=>1
 		]);
 		return $root;
 	}

--- a/app/Academic_Class.php
+++ b/app/Academic_Class.php
@@ -63,7 +63,8 @@ class Academic_Class extends Model
 			"name"=>"All Classes",
 			"author_id"=>0,
 			"created_at"=>Carbon::now()->toDateTimeString(),
-			"updated_at"=>Carbon::now()->toDateTimeString()
+			"updated_at"=>Carbon::now()->toDateTimeString(),
+			"status"=>0
 		]);
 		return $root;
 	}

--- a/app/Http/Controllers/ClassController.php
+++ b/app/Http/Controllers/ClassController.php
@@ -144,12 +144,12 @@ class ClassController extends Controller
 		// before deleting the class, make sure it doesn't have any classes attached underneath it
 		if ($class->children()->count() > 0)
 		{
-			abort(405, "You cannot delete a class that has children");
+			abort(403, "You cannot delete a class that has children");
 		}
 		// also make sure it doesn't have any resources attached to it
 		if ($class->resources()->count() > 0)
 		{
-			abort(405, "You cannot delete a class that has resources");
+			abort(403, "You cannot delete a class that has resources");
 		}
 		// actually delete the class
 		$class->delete();

--- a/app/Http/Controllers/GetTree.php
+++ b/app/Http/Controllers/GetTree.php
@@ -209,7 +209,14 @@ class GetTree extends Controller
 		// add author name; it's more useful than the author id
 		// $node->put('author_name', User::find($node->get('author_id'))->name());
 		// send only the attributes that we need
-		$node = $node->only('id', 'name', 'author_id', 'created_at', 'updated_at');
+		if ($this->type == 'class')
+		{
+			$node = $node->only('id', 'name', 'author_id', 'status', 'created_at', 'updated_at');
+		}
+		else
+		{
+			$node = $node->only('id', 'name', 'author_id', 'created_at', 'updated_at');
+		}
 		return $node;
 	}
 

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -269,7 +269,7 @@ class ResourceController extends Controller
 			}
 			else
 			{
-				abort(405, "Detaching this resource will attach it to the root, which is currently not allowed.");
+				abort(403, "Detaching this resource will attach it to the root, which is currently not allowed.");
 			}
 		}
 	}

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -213,7 +213,7 @@ class ResourceController extends Controller
 				'required_without:topics',
 				'integer',
 				Rule::in(
-					ResourceRepository::allowedClasses($resource->id)->pluck('id')->toArray()
+					ResourceRepository::allowedClasses($resource)->pluck('id')->toArray()
 				)
 			],
 		]);

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -264,12 +264,12 @@ class ResourceController extends Controller
 		// so we have to check that this operation is truly allowed first
 		if ($validated['class'])
 		{
-			if (Academic_Class::getRoot()->status == 1) {
-				$resource->class()->dissociate($validated['class'])->save();
+			if (Academic_Class::getRoot()->status == 0) {
+				abort(403, "Detaching this resource will attach it to the root, which is currently not allowed.");
 			}
 			else
 			{
-				abort(403, "Detaching this resource will attach it to the root, which is currently not allowed.");
+				$resource->class()->dissociate($validated['class'])->save();
 			}
 		}
 	}

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -245,9 +245,17 @@ class ResourceController extends Controller
 		// remove the topics (this code is disabled for MVP)
 		// ResourceRepository::detachTopics($resource, $validated['topics']);
 		// remove the class
+		// note that removing a class from a resource will automatically attach the resource to the root
+		// so we have to check that this operation is truly allowed first
 		if ($validated['class'])
-		{			
-			$resource->class()->dissociate($validated['class'])->save();
+		{
+			if (Academic_Class::getRoot()->status == 1) {
+				$resource->class()->dissociate($validated['class'])->save();
+			}
+			else
+			{
+				abort(405, "Detaching this resource will attach it to the root, which is currently not allowed.");
+			}
 		}
 	}
 

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Topic;
 use App\Resource;
 use Carbon\Carbon;
+use App\Academic_Class;
 use App\ResourceContent;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -99,7 +100,7 @@ class ResourceController extends Controller
 		{
 			$resource->class_id = $validated['class_id'];
 		}
-		elseif (Academic_Class::getRoot()->status == 0)
+		elseif (Academic_Class::getRoot()['status'] == 0)
 		{
 			abort(403, "Resources cannot be attached to the root");
 		} // else we will default to the root
@@ -264,7 +265,7 @@ class ResourceController extends Controller
 		// so we have to check that this operation is truly allowed first
 		if ($validated['class'])
 		{
-			if (Academic_Class::getRoot()->status == 0) {
+			if (Academic_Class::getRoot()['status'] == 0) {
 				abort(403, "Detaching this resource will attach it to the root, which is currently not allowed.");
 			}
 			else

--- a/app/Http/Resources/ClassResource.php
+++ b/app/Http/Resources/ClassResource.php
@@ -25,6 +25,7 @@ class ClassResource extends Resource
 		return [
 			'name' => $this->name,
 			'author_name' => $author ? $author->name() : null,
+			'status' => $this->status,
 			'created' => $this->created_at->format($date_format),
 			'updated' => $this->updated_at->format($date_format)
 		];

--- a/app/Repositories/ResourceRepository.php
+++ b/app/Repositories/ResourceRepository.php
@@ -242,7 +242,7 @@ class ResourceRepository
 	 */
 	public static function allowedClasses($resource)
 	{
-		// resources can only be added to leaf classes
-		return ClassRepository::getLeafClasses();
+		// resources can be added to any class that doesn't have a status of 0
+		return Academic_Class::where('status', 1)->get();
 	}
 }

--- a/app/Repositories/ResourceRepository.php
+++ b/app/Repositories/ResourceRepository.php
@@ -237,7 +237,7 @@ class ResourceRepository
 
 	/**
 	 * which classes is this resource allowed to be added to?
-	 * @param  Resource 	$resource 	the resource whose allowedClasses you'd like to get
+	 * @param  Resource|null 	$resource 	the resource whose allowedClasses you'd like to get; may be null if the resource hasn't been created yet
 	 * @return Collection
 	 */
 	public static function allowedClasses($resource)

--- a/database/migrations/2019_02_23_045220_add_class_status_column.php
+++ b/database/migrations/2019_02_23_045220_add_class_status_column.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddClassStatusColumn extends Migration
+{
+	/**
+	 * Run the migrations.
+	 * The status column will indicate whether this class can be attached to resources. It defaults to allowed
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('classes', function (Blueprint $table) {
+			$table->integer('status')->default(1);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		$table->dropColumn('status');
+	}
+}

--- a/database/seeds/ResourceClassTableSeeder.php
+++ b/database/seeds/ResourceClassTableSeeder.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Resource;
+use App\Academic_Class;
 use Illuminate\Database\Seeder;
 use App\Repositories\ClassRepository;
+use App\Repositories\ResourceRepository;
 
 class ResourceClassTableSeeder extends Seeder
 {
@@ -18,20 +20,21 @@ class ResourceClassTableSeeder extends Seeder
 	 */
 	public function run()
 	{
-		// big picture: iterate through each resource and pick a class for them from the leaf classes
-		// since we want every resource to have at least one topic
+		// big picture: iterate through each resource and pick a class for them from the allowed classes
+		// since we want every resource to have at least one class
 		
-		// get the leaf classes
-		$classes = ClassRepository::getLeafClasses();
+		// get the allowed classes
+		$classes = Academic_Class::all();
 		
 		Resource::all()->shuffle()->each(
 			function($resource) use ($classes)
 			{
+				$available_classes = ResourceRepository::allowedClasses($resource);
 				$class = null;
 				// pick a class if one exists
 				while (is_null($class) && $classes->count() > 0)
 				{
-					$class = $classes->random();
+					$class = $classes->intersect($available_classes)->random();
 					// if this class already has too many resources
 					if ($class->resources()->count() >= self::NUM_MAX_RESOURCES)
 					{


### PR DESCRIPTION
See issue #133

## Add status attribute to classes
Inform Max and Yuki about which classes can be attached to resources using the "status" attribute.
A value of 1 indicates that it can be attached to resources (and a value of 0 disallows this behavior)
Thus, `classes.json` will now return
```
{
    "name":"Class 1",
    "author_name":"Alena Kiehn",
    "status":1,
    "created":"Jan 1, 2019 11:53 PM",
    "updated":"Jan 1, 2019 11:54 PM"
}
```
and nodes returned by `tree.class` will also have a `status` attribute.

## Make `class_id` required for resource creation
Make `class_id` a required attribute to be sent in `resources.store`. This is what it should look like from now on:
```
{
    "name":"Resource 2",
    "use_id":1,
    "class_id":1,
    "contents":[
        {
            "name":"Resource Content 2",
            "type":"link",
            "content":"http://www.hessel.com"
        }
    ]
}
```
where `class_id` can be 0 if you want to attach the resource to the root.